### PR TITLE
Incorrect type check

### DIFF
--- a/lib/user_notification_sender.js
+++ b/lib/user_notification_sender.js
@@ -19,7 +19,8 @@ UserNotificationSender.prototype = Object.create(SenderBase.prototype);
 UserNotificationSender.prototype.constructor = UserNotificationSender;
 
 UserNotificationSender.prototype.sendNoRetry = function(message, notificationKey, callback) {
-    var recipient = notificationKey instanceof String ? {notificationKey: notificationKey} : notificationKey;
+    var recipient = Object.prototype.toString.call(notificationKey) === '[object String]' ?
+        { notificationKey } : notificationKey;
     return this.sendBaseNoRetry(message, recipient, callback);
 };
 


### PR DESCRIPTION
JavaScript distinguishes between String objects and primitive string values (strings created using quotes, double-quotes, or templates), so instanceof only works on String objects and the most reliable, most likely to retain support, method is using Object.prototype.toString.

![string type check](https://cloud.githubusercontent.com/assets/6889054/23931172/3b5e75ca-0907-11e7-86d3-3e70c8620f6f.png)

