### PR TITLE
Allow node >= 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
   },
   "optionalDependencies": {},
   "engines": {
-    "node": "6.x"
+    "node": ">=6.x"
   }
 }


### PR DESCRIPTION
- can't upgrade Rove until we allow > 6.x